### PR TITLE
Fix header height handling

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -73,7 +73,7 @@
 .header {
   position: sticky;
   top: 0;
-  height: 60px;
+  min-height: 60px;
   background: white;
   box-shadow: 0 2px 10px rgba(0,0,0,0.08);
   z-index: 1000;
@@ -85,7 +85,6 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 100%;
   padding: 0 2rem;
   max-width: 1400px;
   margin: 0 auto;
@@ -324,7 +323,7 @@
 
 @media (max-width: 768px) {
   .header {
-    height: 70px;
+    min-height: 70px;
   }
   
   .header-content {


### PR DESCRIPTION
## Summary
- remove fixed height from the header and use `min-height` instead
- keep `.header-content` flexible so items stay centered

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849c61cadbc8331bd3164ea8ee58147