### PR TITLE
Refine navigation alignment

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -166,7 +166,7 @@
   color: #444;
   font-weight: 500;
   font-size: 1rem;
-  padding: 0.75rem 1rem;
+  padding: 0.6rem 1rem;
   border-radius: 12px;
   transition: all 0.25s ease;
   line-height: 1;
@@ -179,6 +179,9 @@
 }
 
 .nav a i {
+  display: flex;
+  align-items: center;
+  line-height: 1;
   font-size: 1rem;
   transition: all 0.2s ease;
   flex-shrink: 0;
@@ -316,7 +319,7 @@
   }
   
   .nav a {
-    padding: 0.8rem 1rem;
+    padding: 0.7rem 1rem;
     font-size: 0.95rem;
     gap: 0.6rem;
   }


### PR DESCRIPTION
## Summary
- refine `.nav a` padding
- center navigation icons with `display:flex`

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6849c61e12908331af655129d466eb78